### PR TITLE
Use Slack API provided rate limit Retry-After value, pretty-print JSON

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,8 +39,6 @@ Options:
         user password (required when -token not specified)
   -team string
         Slack team (required when -token not specified)
-  -rate-limit duration
-        upload rate limit (1 emoji per ...) (default 2s)
 
   -notify-channel string
         notify this channel on successful uploads


### PR DESCRIPTION
Hi there!

I came across this library recently and had intended to use it to upload some ~1800 emojis to my workspace. Unfortunately when doing so we hit the rate limit quite often even when supplying the `-rate-limit` flag.

It appears that the `emoji.add` endpoint has a limit of 20 requests per minute (3 seconds between requests after the initial burst of 20 has been hit).

Fortunately the fix is simple. When we get rate limited by Slack (HTTP 429 resp) they provide a `Retry-After` header value which can be found in the docs here. https://api.slack.com/docs/rate-limits#headers

I've added logic to retry after waiting the value of `Retry-After` and it seems to work well. One side-effect is that we need to remove the ticking channels, waitgroup, and the `-rate-limit` flag but since the rate limit happens per user token, it may not be beneficial to bother with running multiple concurrent requests. Basically if you have fewer than 20 emojis to upload it would be faster with the previous concurrent logic but if you have more than 20 emojis you will greatly benefit from serially uploading and waiting for the rate limit.

Future improvements could implement both the rate limit delay and multiple go routines but will add additional complexity to the code.

Additionally, I've setup the summary JSON to be pretty-printed out after the upload has finished.

Thanks for creating this awesome tool! 